### PR TITLE
Adjust some typing checks.

### DIFF
--- a/sd_data_adapter/api/search.py
+++ b/sd_data_adapter/api/search.py
@@ -1,10 +1,10 @@
-from typing import List
+from typing import List, Union
 
 from ..client import DAClient
 from ..models import to_object, SmartDataModel
 
 
-def get_by_id(id: str) -> SmartDataModel | None:
+def get_by_id(id: str) -> Union[SmartDataModel, None]:
     if not isinstance(id, str):
         raise TypeError('id must be a string')
 
@@ -20,7 +20,7 @@ def get_by_id(id: str) -> SmartDataModel | None:
     return to_object(entity)
 
 
-def search(params: dict = None) -> List[SmartDataModel] | None:
+def search(params: dict = None) -> Union[List[SmartDataModel], None]:
     allowed_params = ['ctx', 'type', 'q', 'limit', 'max']
     if not isinstance(params, dict):
         raise TypeError('params must be a dict')

--- a/sd_data_adapter/models/smartDataModel.py
+++ b/sd_data_adapter/models/smartDataModel.py
@@ -1,6 +1,6 @@
 import dataclasses
 import uuid
-from types import NoneType
+# from types import NoneType
 from typing import Union, List, Optional
 
 from geojson import LineString, Point, Polygon, MultiPoint, MultiLineString, MultiPolygon, Feature, FeatureCollection
@@ -37,7 +37,7 @@ class Util:
     pass
 
 
-Property = Union[bool, int, float, str, List[str], SmartDataModel, List[SmartDataModel], List[Util], NoneType]
+Property = Union[bool, int, float, str, List[str], SmartDataModel, List[SmartDataModel], List[Util], None]
 Relationship = Union[str, List[str]]
 GeoProperty = Union[Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, Feature, FeatureCollection]
 


### PR DESCRIPTION
I adjusted some typing checks in the API code. These changes worked for my code; the previous one gave me some errors like NoneType not existing or something. Also, apparently the or (this symbol | ) sign is not allowed in annotations, so I changed it to use typing Union.
It might also be my version of Python (3.9) but I figure the API should be a bit more robust to avoid these kind of errors.

Please feel free to suggest further changes if there is a more robust way of handling these None types or Union types.