### PR TITLE
bugfix optional

### DIFF
--- a/sd_data_adapter/models/smartDataModel.py
+++ b/sd_data_adapter/models/smartDataModel.py
@@ -55,14 +55,14 @@ def to_ngsi_ld(obj: SmartDataModel):
 
         if field.type == Property:
             entity.prop(field.name, field_value)
-        elif field.type == Relationship:
+        elif field.type == Relationship or field.type == Optional[Relationship]:
             entity.rel(field.name, field_value)
         elif field.type == GeoProperty:
             # NOTE: The underlying library only accepts
             # [Point, LineString, Polygon, MultiPoint]
             # as valid geojson inputs at this point. The current
             # workaround is to store location as a regular prop.
-            
+
             # entity.gprop(field.name, field_value)
             entity.prop(field.name, field_value)
 


### PR DESCRIPTION
hasAgriSoil apparently is optional. The function `to_ngsi_ld(obj)` seems to ignore optional-relationships. As a result the hasAgriSoil is set to `None` 
This fix is a bit of a hack. Other solutions may fit better.